### PR TITLE
Get rid of tombstones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghaladb"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Matt Gathu <mattgathu@gmail.com>"]
 edition = "2021"
 description = "LSM tree based key value store with keys and values separation."

--- a/src/core.rs
+++ b/src/core.rs
@@ -12,28 +12,6 @@ pub(crate) trait MemSize {
     fn mem_sz(&self) -> usize;
 }
 
-/// A list of possible data pointer states.
-#[derive(Debug, Copy, Clone, PartialEq, Encode, Decode)]
-pub(crate) enum ValueEntry {
-    /// A deleted value entry
-    Tombstone,
-    /// A valid pointer to data on disk.
-    Val(DataPtr),
-}
-impl Default for ValueEntry {
-    fn default() -> Self {
-        Self::Tombstone
-    }
-}
-impl MemSize for ValueEntry {
-    fn mem_sz(&self) -> usize {
-        match self {
-            Self::Val(dp) => dp.mem_sz(),
-            Self::Tombstone => 0usize,
-        }
-    }
-}
-
 impl MemSize for Bytes {
     fn mem_sz(&self) -> usize {
         self.len()
@@ -64,9 +42,7 @@ impl DataPtr {
             compressed,
         }
     }
-    pub fn mem_sz(&self) -> usize {
-        std::mem::size_of_val(self)
-    }
+
     pub fn serde_sz() -> usize {
         // u64 + u64 + u32 +bool
         21

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use crate::{
     core::VlogNum,
     error::GhalaDbResult,
-    keys::Skt,
+    keys::Keys,
     vlog::{DataEntry, VlogReader},
 };
 
@@ -44,7 +44,7 @@ impl Janitor {
         Ok(Self { vnum, vlog_iter })
     }
 
-    pub fn sweep(&mut self, keys: &mut Skt) -> GhalaDbResult<Option<DataEntry>> {
+    pub fn sweep(&mut self, keys: &mut Keys) -> GhalaDbResult<Option<DataEntry>> {
         trace!("Janitor::sweep");
         loop {
             match self.vlog_iter.next_entry()? {

--- a/src/ghaladb.rs
+++ b/src/ghaladb.rs
@@ -8,7 +8,7 @@ use crate::{
     dec::Dec,
     error::{GhalaDbError, GhalaDbResult},
     gc::Janitor,
-    keys::Skt,
+    keys::Keys,
     utils::t,
     vlog::{DataEntry, VlogsMan},
 };
@@ -21,8 +21,8 @@ where
     K: Encode + Decode,
     V: Encode + Decode,
 {
-    /// Sorted Keys Table
-    keys: Skt,
+    /// Keys Table
+    keys: Keys,
     /// Values logs manager
     vlogs_man: VlogsMan,
     /// Garbage Collector
@@ -46,10 +46,10 @@ where
         trace!("GhalaDb::new path: {}", path.as_ref().display());
         let opts = options.unwrap_or_else(|| DatabaseOptions::builder().build());
         Self::init_dir(path.as_ref())?;
-        let skt_path = path.as_ref().join("skt");
+        let keys_path = path.as_ref().join("keys");
 
         let vlogs_man = VlogsMan::new(path.as_ref(), opts)?;
-        let keys = Skt::from_path(skt_path, opts)?;
+        let keys = Keys::from_path(keys_path, opts)?;
         let janitor = None;
         let db = GhalaDb {
             keys,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ for applications that have small-sized keys.
 <div class="warning">!! GhalaDb is experimental software and might not be suitable for your use case.</div>
 
 
-```rust
+```ignore
 use ghaladb::{GhalaDb, GhalaDbResult};
 
 fn main() -> GhalaDbResult<()> {


### PR DESCRIPTION
What
--
Get rid of tombstones

Since we no longer compact keys, we no longer need to track deleted keys using tombstones.

A missing key is considered deleted.