### PR TITLE
Rename Janitor to GarbageCollector

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// A Lightweight Garbage Collector
 ///
-/// The janitor reads data entries in a values log and checks
+/// The GC reads data entries in a values log and checks
 /// if they are still valid by doing a lookup for the current data
 /// pointer associated to a key and comparing it to the one on the log.
 ///
@@ -17,35 +17,35 @@ use crate::{
 /// the key got updated and we can safely delete the stale entry in the values logs.
 /// If the pointers match then the data is still live and valid.
 ///
-/// The janitor returns a live data entry when found. The database will re-insert it
+/// The GC returns a live data entry when found. The database will re-insert it
 /// and trigger more sweeping later.
 ///
-/// Once the janitor goes through an entire values log, the database will drop it.
+/// Once the GC goes through an entire values log, the database will drop it.
 ///
 /// NOTE
 /// --
 /// The sweeping is driven by the database.
 ///
-/// The janitor will stop every time a live data entry is found.
+/// The GC will stop every time a live data entry is found.
 /// The idea is we can do this sweeping inline when doing writes.
 ///
 /// If the vlog entries are all stale, then the vlog will not stop until it goes through
 /// the entire vlog. This could be problematic.
 /// TODO: handle this edge case
-pub(crate) struct Janitor {
+pub(crate) struct GarbageCollector {
     vnum: VlogNum,
     vlog_iter: VlogReader,
 }
 
-impl Janitor {
+impl GarbageCollector {
     pub fn new(vnum: VlogNum, path: &Path) -> GhalaDbResult<Self> {
-        debug!("init janitor for vlog: {vnum} at: {path:?}");
+        debug!("GarbageCollector::new vlog: {vnum} at: {path:?}");
         let vlog_iter = VlogReader::from_path(path)?;
         Ok(Self { vnum, vlog_iter })
     }
 
     pub fn sweep(&mut self, keys: &mut Keys) -> GhalaDbResult<Option<DataEntry>> {
-        trace!("Janitor::sweep");
+        trace!("GarbageCollector::sweep");
         loop {
             match self.vlog_iter.next_entry()? {
                 None => return Ok(None),


### PR DESCRIPTION
What
--
Rename Janitor to GarbageCollector

Why
--
Simplicity - remove cognitive overload by using a familiar term.