### PR TITLE
Make key references generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghaladb"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Matt Gathu <mattgathu@gmail.com>"]
 edition = "2021"
 description = "LSM tree based key value store with keys and values separation."

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -9,7 +9,7 @@ fn gen_bytes(rng: &mut ThreadRng, len: usize) -> Vec<u8> {
 fn main() -> GhalaDbResult<()> {
     let mut rng = rand::thread_rng();
     let tmp_dir = tempdir()?;
-    let mut db = GhalaDb::new(tmp_dir.path(), None)?;
+    let mut db: GhalaDb<Vec<u8>, Vec<u8>> = GhalaDb::new(tmp_dir.path(), None)?;
     let mut data = (0usize..1_000_000)
         .map(|_| {
             let (k, v) =
@@ -18,7 +18,7 @@ fn main() -> GhalaDbResult<()> {
         })
         .collect::<Vec<_>>();
     for (k, v) in &data {
-        db.put(k,v)?;
+        db.put(k, v)?;
     }
     for (k, _) in &data {
         db.get(k)?;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 use ghaladb::{GhalaDb, GhalaDbResult};
 
 fn main() -> GhalaDbResult<()> {
-    let mut db = GhalaDb::new("/tmp/ghaladb", None)?;
+    let mut db: GhalaDb<String, String> = GhalaDb::new("/tmp/ghaladb", None)?;
     let key = "king".to_owned();
     let val = "queen".to_owned();
     db.put(&key, &val)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 //! GhalaDb's errors module.
-//!
 use crate::core::VlogNum;
 use std::path::PathBuf;
 use thiserror::Error;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -18,8 +18,9 @@ use std::{
 /// Keys
 ///
 /// This is an in-memory map that stores keys and their data pointer.
-/// It is automatically synced to disk during datastore shutdown (when GhalaDb is dropped)
-/// but it can also be synced manually using the `sync` method of GhalaDb.
+/// It is automatically synced to disk during datastore shutdown (when GhalaDb
+/// is dropped) but it can also be synced manually using the `sync` method of
+/// GhalaDb.
 #[derive(Encode, Decode, Debug)]
 pub(crate) struct Keys {
     map: BTreeMap<Bytes, DataPtr>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,11 @@ mod ghaladb;
 mod keys;
 mod utils;
 mod vlog;
-pub use crate::config::DatabaseOptions;
-pub use crate::error::{GhalaDbError, GhalaDbResult};
-pub use crate::ghaladb::GhalaDb;
+pub use crate::{
+    config::DatabaseOptions,
+    error::{GhalaDbError, GhalaDbResult},
+    ghaladb::GhalaDb,
+};
 
 //
 //          _|                  _|                  _|  _|

--- a/src/vlog.rs
+++ b/src/vlog.rs
@@ -505,7 +505,6 @@ impl Drop for VlogsMan {
 mod tests {
 
     use super::*;
-    use crate::core::FixtureGen;
     use tempfile::{tempdir, TempDir};
     fn init_vlog(temp_dir: &TempDir) -> GhalaDbResult<Vlog> {
         let file_path = temp_dir.path().join("test_vlog.db");


### PR DESCRIPTION
What
--
Make key references generic over the type of the underlying key data.

This will allow using borrowed types such as &str where references of key type e.g String are expected.

See: https://doc.rust-lang.org/std/borrow/trait.Borrow.htmll 